### PR TITLE
Add tests for standalone server

### DIFF
--- a/mod_pywebsocket/request_handler.py
+++ b/mod_pywebsocket/request_handler.py
@@ -208,7 +208,7 @@ class WebSocketRequestHandler(CGIHTTPServer.CGIHTTPRequestHandler):
             return False
 
         if self._options.use_basic_auth:
-            auth = self.headers.getheader('Authorization')
+            auth = self.headers.get('Authorization')
             if auth != self._options.basic_auth_credential:
                 self.send_response(401)
                 self.send_header('WWW-Authenticate',

--- a/test/client_for_testing.py
+++ b/test/client_for_testing.py
@@ -316,6 +316,12 @@ class WebSocketHandshake(object):
 
         fields.append(u'Sec-WebSocket-Version: %d\r\n' % self._options.version)
 
+        if self._options.use_basic_auth:
+            credential = 'Basic ' + base64.b64encode(
+                self._options.basic_auth_credential.encode('UTF-8')).decode()
+            fields.append(u'Authorization: %s\r\n' % credential)
+
+
         # Setting up extensions.
         if len(self._options.extensions) > 0:
             fields.append(u'Sec-WebSocket-Extensions: %s\r\n' %
@@ -609,6 +615,8 @@ class ClientOptions(object):
         self.server_port = -1
         self.socket_timeout = 1000
         self.use_tls = False
+        self.use_basic_auth = False
+        self.basic_auth_credential = 'test:test'
         self.extensions = []
 
 

--- a/test/client_for_testing.py
+++ b/test/client_for_testing.py
@@ -321,7 +321,6 @@ class WebSocketHandshake(object):
                 self._options.basic_auth_credential.encode('UTF-8')).decode()
             fields.append(u'Authorization: %s\r\n' % credential)
 
-
         # Setting up extensions.
         if len(self._options.extensions) > 0:
             fields.append(u'Sec-WebSocket-Extensions: %s\r\n' %

--- a/test/test_endtoend.py
+++ b/test/test_endtoend.py
@@ -245,8 +245,11 @@ class EndToEndHyBiTest(EndToEndTestBase):
         finally:
             self._close_server(server)
 
-    def _run_close_with_code_and_reason_test(self, test_function, code,
-                                             reason, server_option=[]):
+    def _run_close_with_code_and_reason_test(self,
+                                             test_function,
+                                             code,
+                                             reason,
+                                             server_option=[]):
         server = self._run_server()
         try:
             time.sleep(_SERVER_WARMUP_IN_SEC)
@@ -619,9 +622,10 @@ class EndToEndHyBiTest(EndToEndTestBase):
         # with self.assertRaises(Exception):
 
         with self.assertRaises(client_for_testing.HttpStatusException) as e:
-            self._run_test_with_client_options(_check_handshake_with_basic_auth,
-                                               options,
-                                               server_option=['--basic-auth'])
+            self._run_test_with_client_options(
+                _check_handshake_with_basic_auth,
+                options,
+                server_option=['--basic-auth'])
             self.assertEqual(101, e.exception.status)
 
 

--- a/test/test_msgutil.py
+++ b/test/test_msgutil.py
@@ -552,7 +552,6 @@ class PerMessageDeflateTest(unittest.TestCase):
         compressed_empty = compressed_empty[:-4]
         expected += b'\x80%c' % len(compressed_empty)
         expected += compressed_empty
-        print('%r' % expected)
         self.assertEqual(expected, request.connection.written_data())
 
     def test_send_message_fragmented_empty_last_frame(self):
@@ -732,7 +731,6 @@ class PerMessageDeflateTest(unittest.TestCase):
 
             frame_count += 1
 
-        print("Chunk sizes: %r" % chunk_sizes)
         self.assertTrue(len(chunk_sizes) > 10)
 
         # Close frame
@@ -834,9 +832,7 @@ class PerMessageDeflateTest(unittest.TestCase):
                     compress = None
                     finish_used = True
 
-        print("Chunk sizes: %r" % chunk_sizes)
         self.assertTrue(len(chunk_sizes) > 10)
-        print("Methods: %r" % methods)
         self.assertTrue(sync_used)
         self.assertTrue(finish_used)
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -167,7 +167,7 @@ class InflaterDeflaterTest(unittest.TestCase):
             [int2byte(random.randint(0, 255)) for i in range(100 * 1024)])
 
         chunked_input = get_random_section(source, 10)
-        print("Input chunk sizes: %r" % [len(c) for c in chunked_input])
+        # print("Input chunk sizes: %r" % [len(c) for c in chunked_input])
 
         deflater = util._Deflater(15)
         compressed = []
@@ -176,8 +176,8 @@ class InflaterDeflaterTest(unittest.TestCase):
         compressed.append(deflater.compress_and_finish(b''))
 
         chunked_expectation = get_random_section(source, 10)
-        print("Expectation chunk sizes: %r" %
-              [len(c) for c in chunked_expectation])
+        # print("Expectation chunk sizes: %r" %
+        #       [len(c) for c in chunked_expectation])
 
         inflater = util._Inflater(15)
         inflater.append(b''.join(compressed))

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -167,7 +167,6 @@ class InflaterDeflaterTest(unittest.TestCase):
             [int2byte(random.randint(0, 255)) for i in range(100 * 1024)])
 
         chunked_input = get_random_section(source, 10)
-        # print("Input chunk sizes: %r" % [len(c) for c in chunked_input])
 
         deflater = util._Deflater(15)
         compressed = []
@@ -176,8 +175,6 @@ class InflaterDeflaterTest(unittest.TestCase):
         compressed.append(deflater.compress_and_finish(b''))
 
         chunked_expectation = get_random_section(source, 10)
-        # print("Expectation chunk sizes: %r" %
-        #       [len(c) for c in chunked_expectation])
 
         inflater = util._Inflater(15)
         inflater.append(b''.join(compressed))


### PR DESCRIPTION
This patch updates test_endtoend.py to achieve higher coverage.

It particularly adds the following tests:
- Test using basic_auth_credential (correctly and incorrectly)
- Test making invalid URIs for standalone to process
(The individual components are tested in the unit test test_http_header_util.py, but the current test_endtoend serves as a simple integrity test, so we check the responses here as well).

It also fixes client_for_testing to support basic_auth_credential, and also fixes a bug found in request_handler with the tests.

Please take a look.
