### PR TITLE
Change invalid copyright header in websocket_server.py

### DIFF
--- a/mod_pywebsocket/websocket_server.py
+++ b/mod_pywebsocket/websocket_server.py
@@ -1,4 +1,4 @@
-# Copyright 202, Google Inc.
+# Copyright 2020, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This patch fixes the invalid copyright header in websocket_server.py/

Change-Id: If14d3065ad22709e0d3f3b34f51086c3174402c1