### PR TITLE
Fix Sphinx reST parsing errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Run this to read the general document:
 $ pydoc mod_pywebsocket
 ```
 
-Please see [Wiki](../../wiki) for more details.
+Please see [Wiki](https://github.com/GoogleChromeLabs/pywebsocket3/wiki) for more details.
 
 # INSTALL #
 

--- a/mod_pywebsocket/extensions.py
+++ b/mod_pywebsocket/extensions.py
@@ -273,6 +273,7 @@ class PerMessageDeflateExtensionProcessor(ExtensionProcessorInterface):
 
         If this method has been called with True and an offer without the
         client_max_window_bits extension parameter is received,
+
         - (When processing the permessage-deflate extension) this processor
           declines the request.
         - (When processing the permessage-compress extension) this processor

--- a/mod_pywebsocket/http_header_util.py
+++ b/mod_pywebsocket/http_header_util.py
@@ -120,7 +120,7 @@ def consume_lws(state):
 
 
 def consume_lwses(state):
-    """Consumes *LWS from the head."""
+    r"""Consumes \*LWS from the head."""
 
     while consume_lws(state):
         pass


### PR DESCRIPTION
We are trying to use Sphinx to build PyDocs for this project, to be
included in web-platform-tests.org. In the process, we encountered some
reST parsing errors.