### PR TITLE
Make tests work with python 2 on Windows

### DIFF
--- a/test/test_endtoend.py
+++ b/test/test_endtoend.py
@@ -153,8 +153,9 @@ class EndToEndTestBase(unittest.TestCase):
     # TODO(tyoshino): Use tearDown to kill the server.
 
     def _run_python_command(self, commandline, stdout=None, stderr=None):
+        close_fds = True if sys.platform != 'win32' else None
         return subprocess.Popen([sys.executable] + commandline,
-                                close_fds=True,
+                                close_fds=close_fds,
                                 stdout=stdout,
                                 stderr=stderr)
 


### PR DESCRIPTION
Python 2 on Windows doesn't support the close_fds argument to
Popen. Stop passing that argument on Windows.