### PR TITLE
Fix version comparisons

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ _USE_FAST_MASKING = False
 
 # This is used since python_requires field is not recognized with
 # pip version 9.0.0 and earlier
-if sys.version < '2.7':
+if sys.hexversion < 0x020700f0:
     print('%s requires Python 2.7 or later.' % _PACKAGE_NAME, file=sys.stderr)
     sys.exit(1)
 

--- a/test/test_http_header_util.py
+++ b/test/test_http_header_util.py
@@ -79,7 +79,7 @@ class UnitTest(unittest.TestCase):
 
         host, port, resource = http_header_util.parse_uri(
             'ws://localhost:-1/ws')
-        if sys.version >= '3.6':
+        if sys.hexversion >= 0x030600f0:
             self.assertEqual(None, resource)
         else:
             self.assertEqual('localhost', host)


### PR DESCRIPTION
String comparisons don't work properly for Python versions because for
example "3.10.0" < "3.8.0". Use sys.hexversion instead.