### PR TITLE
Give up expecting echo_client to be unicode safe

### DIFF
--- a/example/echo_client.py
+++ b/example/echo_client.py
@@ -599,6 +599,10 @@ class EchoClient(object):
 
 
 def main():
+    # Output in UTF-8 on Python 2. This will do the wrong thing if the
+    # locale is not UTF-8. On Python 3, the output encoding is correct
+    # for the locale but doesn't necessarily support all unicode
+    # characters. This problem is particularly prevalent on Windows.
     if six.PY2:
         sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
 
@@ -636,7 +640,7 @@ def main():
         '--message',
         dest='message',
         type=six.text_type,
-        default=u'Hello,\u65e5\u672c',
+        default=u'Hello,<>',
         help=('comma-separated messages to send. '
               '%s will force close the connection from server.' %
               _GOODBYE_MESSAGE))

--- a/example/echo_client.py
+++ b/example/echo_client.py
@@ -599,12 +599,14 @@ class EchoClient(object):
 
 
 def main():
-    # Output in UTF-8 on Python 2. This will do the wrong thing if the
-    # locale is not UTF-8. On Python 3, the output encoding is correct
-    # for the locale but doesn't necessarily support all unicode
-    # characters. This problem is particularly prevalent on Windows.
+    # Force Python 2 to use the locale encoding, even when the output is not a
+    # tty. This makes the behaviour the same as Python 3. The encoding won't
+    # necessarily support all unicode characters. This problem is particularly
+    # prevalent on Windows.
     if six.PY2:
-        sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
+        import locale
+        encoding = locale.getpreferredencoding()
+        sys.stdout = codecs.getwriter(encoding)(sys.stdout)
 
     parser = argparse.ArgumentParser()
     # We accept --command_line_flag style flags which is the same as Google

--- a/test/test_endtoend.py
+++ b/test/test_endtoend.py
@@ -633,7 +633,16 @@ class EndToEndTestWithEchoClient(EndToEndTestBase):
 
     def _check_example_echo_client_result(self, expected, stdoutdata,
                                           stderrdata):
+        # This is not right in Python 3 if the locale does not use
+        # utf-8, which is why the tests only use ASCII characters.
         actual = stdoutdata.decode("utf-8")
+
+        # In Python 3 on Windows we get "\r\n" terminators back from
+        # the subprocess and we need to replace them with "\n" to get
+        # a match. This is a bit of a hack, but avoids platform- and
+        # version- specific code.
+        actual = actual.replace('\r\n', '\n')
+
         if actual != expected:
             raise Exception('Unexpected result on example echo client: '
                             '%r (expected) vs %r (actual)' %
@@ -655,8 +664,8 @@ class EndToEndTestWithEchoClient(EndToEndTestBase):
             # Expected output for the default messages.
             default_expectation = (u'Send: Hello\n'
                                    u'Recv: Hello\n'
-                                   u'Send: \u65e5\u672c\n'
-                                   u'Recv: \u65e5\u672c\n'
+                                   u'Send: <>\n'
+                                   u'Recv: <>\n'
                                    u'Send close\n'
                                    u'Recv ack\n')
 

--- a/test/test_endtoend.py
+++ b/test/test_endtoend.py
@@ -32,6 +32,7 @@
 """
 
 from __future__ import absolute_import
+import locale
 import logging
 import os
 import signal
@@ -633,9 +634,7 @@ class EndToEndTestWithEchoClient(EndToEndTestBase):
 
     def _check_example_echo_client_result(self, expected, stdoutdata,
                                           stderrdata):
-        # This is not right in Python 3 if the locale does not use
-        # utf-8, which is why the tests only use ASCII characters.
-        actual = stdoutdata.decode("utf-8")
+        actual = stdoutdata.decode(locale.getpreferredencoding())
 
         # In Python 3 on Windows we get "\r\n" terminators back from
         # the subprocess and we need to replace them with "\n" to get


### PR DESCRIPTION
The example echo_client.py outputs in UTF-8 in Python 2 and the locale
encoding in Python 3. test_example_echo_client expects output to be
UTF-8. It's common (usual?) on Windows for the DOS codepage to be
non-UTF-8, so this causes the test to fail.

In general, echo_client.py won't be able to output arbitrary unicode
everywhere, so testing for it is a bit futile anyway.

Only test ASCII characters.