### PR TITLE
Add missing r to regular expression

### DIFF
--- a/mod_pywebsocket/websocket_server.py
+++ b/mod_pywebsocket/websocket_server.py
@@ -61,7 +61,7 @@ def _alias_handlers(dispatcher, websock_handlers_map_file):
         for line in f:
             if line[0] == '#' or line.isspace():
                 continue
-            m = re.match('(\S+)\s+(\S+)$', line)
+            m = re.match(r'(\S+)\s+(\S+)$', line)
             if not m:
                 logging.warning('Wrong format in map file:' + line)
                 continue


### PR DESCRIPTION
A regular expression using "\S" was missing the "r" to indicate that it
was a raw string, causing a warning in Python 3. Add the missing "r".

Fixes #26.
