### PR TITLE
Support --handler-encoding option

### DIFF
--- a/mod_pywebsocket/dispatch.py
+++ b/mod_pywebsocket/dispatch.py
@@ -30,6 +30,7 @@
 """
 
 from __future__ import absolute_import
+import io
 import logging
 import os
 import re
@@ -179,7 +180,8 @@ class Dispatcher(object):
     def __init__(self,
                  root_dir,
                  scan_dir=None,
-                 allow_handlers_outside_root_dir=True):
+                 allow_handlers_outside_root_dir=True,
+                 handler_encoding=None):
         """Construct an instance.
 
         Args:
@@ -206,7 +208,8 @@ class Dispatcher(object):
             raise DispatchException('scan_dir:%s must be a directory under '
                                     'root_dir:%s.' % (scan_dir, root_dir))
         self._source_handler_files_in_dir(root_dir, scan_dir,
-                                          allow_handlers_outside_root_dir)
+                                          allow_handlers_outside_root_dir,
+                                          handler_encoding)
 
     def add_resource_path_alias(self, alias_resource_path,
                                 existing_resource_path):
@@ -346,7 +349,8 @@ class Dispatcher(object):
         return handler_suite
 
     def _source_handler_files_in_dir(self, root_dir, scan_dir,
-                                     allow_handlers_outside_root_dir):
+                                     allow_handlers_outside_root_dir,
+                                     handler_encoding):
         """Source all the handler source files in the scan_dir directory.
 
         The resource path is determined relative to root_dir.
@@ -369,7 +373,7 @@ class Dispatcher(object):
                     'Canonical path of %s is not under root directory' % path)
                 continue
             try:
-                with open(path) as handler_file:
+                with io.open(path, encoding=handler_encoding) as handler_file:
                     handler_suite = _source_handler_file(handler_file.read())
             except DispatchException as e:
                 self._source_warnings.append('%s: %s' % (path, e))

--- a/mod_pywebsocket/standalone.py
+++ b/mod_pywebsocket/standalone.py
@@ -361,6 +361,16 @@ def _build_option_parser():
                         type=int,
                         default=_DEFAULT_REQUEST_QUEUE_SIZE,
                         help='request queue size')
+    parser.add_argument(
+        '--handler-encoding',
+        '--handler_encoding',
+        dest='handler_encoding',
+        type=six.text_type,
+        default=None,
+        help=('Text encoding used for loading handlers. '
+              'By default, the encoding from the locale is used when '
+              'reading handler files, but this option can override it. '
+              'Any encoding supported by the codecs module may be used.'))
 
     return parser
 

--- a/mod_pywebsocket/websocket_server.py
+++ b/mod_pywebsocket/websocket_server.py
@@ -89,7 +89,7 @@ class WebSocketServer(socketserver.ThreadingMixIn, BaseHTTPServer.HTTPServer):
         # instantiation.  Dispatcher can be shared because it is thread-safe.
         options.dispatcher = dispatch.Dispatcher(
             options.websock_handlers, options.scan_dir,
-            options.allow_handlers_outside_root_dir)
+            options.allow_handlers_outside_root_dir, options.handler_encoding)
         if options.websock_handlers_map_file:
             _alias_handlers(options.dispatcher,
                             options.websock_handlers_map_file)

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     python_requires='>=2.7',
     install_requires=['six'],
     url='https://github.com/GoogleChromeLabs/pywebsocket3',
-    version='3.0.1',
+    version='3.0.2',
 )
 
 # vi:sts=4 sw=4 et


### PR DESCRIPTION
Permit overriding the locale encoding when reading handler files by
specifying a --handler-encoding command-line option.

Upgrade version number to 3.0.2.