### PR TITLE
Migrate ssl.wrap_socket to SSLContext.wrap_socket

### DIFF
--- a/pywebsocket3/websocket_server.py
+++ b/pywebsocket3/websocket_server.py
@@ -157,12 +157,14 @@ class WebSocketServer(socketserver.ThreadingMixIn, BaseHTTPServer.HTTPServer):
                         client_cert_ = ssl.CERT_REQUIRED
                 else:
                     client_cert_ = ssl.CERT_NONE
-                socket_ = ssl.wrap_socket(
-                    socket_,
-                    keyfile=server_options.private_key,
-                    certfile=server_options.certificate,
-                    ca_certs=server_options.tls_client_ca,
-                    cert_reqs=client_cert_)
+
+                ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+                if server_options.certificate:
+                    ssl_context.load_cert_chain(certfile=server_options.certificate, keyfile=server_options.private_key)
+                if server_options.tls_client_ca:   
+                    ssl_context.load_verify_locations(server_options.tls_client_ca)
+                ssl_context.verify_mode =client_cert_
+                socket_ = ssl_context.wrap_socket(socket_)
             self._sockets.append((socket_, addrinfo))
 
     def server_bind(self):


### PR DESCRIPTION
The ssl.wrap_socket function was removed in 3.12. This PR migrates ssl.wrap_socket to SSLContext.wrap_socket by recreating the logic already used internally by [ssl.wrap_socket](https://github.com/python/cpython/blob/65a0923c708210f393e2dbf5b231ca09c4b045c7/Lib/ssl.py#L1458-L1486) when called from pywebsocket3.

Tested by successfully running WPT locally.

Fixes #38.