### PR TITLE
Specifiy release event to publish to PyPi (#30)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,7 @@
+on:
+  release:
+    types: [released]
+
 jobs:
   pypi-publish:
     name: Upload release to PyPI


### PR DESCRIPTION
This patch adds a trigger event to publish.yml and specifies the release event to when we will publish to PyPi.