### PR TITLE
Add owners

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python3 -m pip install --upgrade pip
-        python3 -m pip install six yapf
+        python3 -m pip install six yapf setuptools
 
     # Build and create dist
     - name: Build Package

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,8 @@ if _USE_FAST_MASKING:
     ])
 
 setup(
-    author='Yuzo Fujishima',
-    author_email='yuzo@chromium.org',
+    author='Adam Rice, Keita Suzuki',
+    author_email='Adam Rice <ricea@chromium.org>, Keita Suzuki <suzukikeita@chromium.org>',
     description='Standalone WebSocket Server for testing purposes.',
     long_description=('pywebsocket3 is a standalone server for '
                       'the WebSocket Protocol (RFC 6455). '


### PR DESCRIPTION
This change updates setup.py to reflect the current owners of pywebsocket3.

Since setup.py does not support multiple authors natively, we need to pass a comma seperated author list.